### PR TITLE
Append "--disable-warnings-as-errors" to scons invocation to fix broken builds.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN mkdir -p /var/downloads \
 
 RUN mkdir -p /usr/local/bin
 RUN cd /var/downloads/mongo \
- && scons mongod --64 --ssl -j8 --no-glibc-check --prefix=/usr/local \
+ && scons mongod --64 --ssl -j8 --no-glibc-check --prefix=/usr/local --disable-warnings-as-errors \
  && cp /var/downloads/mongo/build/linux2/64/ssl/mongo/mongod /usr/local/bin \
  && rm -rf /var/downloads
 


### PR DESCRIPTION
Hi there,

I ran into some errors (actually, they were warnings that were being treated as stop conditions) while trying to build this image recently; this PR simply fixes the build process.

Thanks for mongo-ssl!

---
##### Append "--disable-warnings-as-errors" to scons invocation to fix broken builds.

Older versions of MongoDB may fail to build with more recent compilers
(as was the case with the versions specified in this Dockerfile).

See note here:
https://github.com/mongodb/mongo/wiki/Build-Mongodb-From-Source#building-with-scons
